### PR TITLE
Updated `RiakPbcSocket.Write()` to send the message in 16KB chunks

### DIFF
--- a/CorrugatedIron/Comms/RiakPbcSocket.cs
+++ b/CorrugatedIron/Comms/RiakPbcSocket.cs
@@ -117,6 +117,7 @@ namespace CorrugatedIron.Comms
             const int sizeSize = sizeof(int);
             const int codeSize = sizeof(byte);
             const int headerSize = sizeSize + codeSize;
+            const int sendBufferSize = 1024 * 16;
             byte[] messageBody;
             long messageLength = 0;
 
@@ -140,9 +141,18 @@ namespace CorrugatedIron.Comms
             Array.Copy(size, messageBody, sizeSize);
             messageBody[sizeSize] = (byte)messageCode;
 
-            if(PbcSocket.Send(messageBody, (int)messageLength, SocketFlags.None) == 0)
+            int bytesToSend = (int)messageLength;
+            int position = 0;
+
+            while (bytesToSend > 0)
             {
-                throw new RiakException("Failed to send data to server - Timed Out: {0}:{1}".Fmt(_server, _port));
+                int sent = PbcSocket.Send(messageBody, position, bytesToSend <= sendBufferSize ? bytesToSend : sendBufferSize, SocketFlags.None);
+                if (sent == 0)
+                {
+                    throw new RiakException("Failed to send data to server - Timed Out: {0}:{1}".Fmt(_server, _port));
+                }
+                position += sent;
+                bytesToSend -= sent;
             }
         }
 


### PR DESCRIPTION
## Change

Updated `RiakPbcSocket.Write()` to send the message in 16KB chunks
instead of all at once. This addresses issues seen when PUTting large
messages.
## Details
### Problem

Sending a single large buffer via `Socket.Send()` returns immediately.
After the send, the code then proceeds to call `Socket.Read()` in order
to obtain the result of the operation

This works fine for small messages because the Riak server is able to accept 
and ACK the TCP packets and send a reply before the `Socket.Receive()` request is issued.

In the case of writing large messages, `Socket.Receive()` is called too soon, before the 
bytes have been fully sent and ACK'd, resulting in a SocketException (timeout).
### Fix

`Socket.Send()` will block when called if the bytes from a previously
issued Send() call has yet to be fully sent. By looping through the message
and sending in small chunks, we are able to avoid the problem above.
### Examples

When sending a 3MB buffer all at once, `Socket.Send()` returns
immediatly and a `Socket.Receive()` is issued before the data has completed
transmitting, ultimately resulting in a timeout (default timeout = 2 seconds).

On the other hand, splitting this 3MB message into 16KB chunks,
each call to `Socket.Send()` waits for the previous call to
complete.

From this, when the `Socket.Receive()` command is issued,
we only have to wait until the last 16KB chunk to complete, because
we can safely assume all previous chunks have been transmitted.

Unless the network link is very slow, the final 16KB chunk will complete
and the response sent within the 2 second timeout receive window.
