### PR TITLE
Modified .Last() call to reduce executions.

### DIFF
--- a/CorrugatedIron/RiakClient.cs
+++ b/CorrugatedIron/RiakClient.cs
@@ -794,10 +794,12 @@ namespace CorrugatedIron
             var query = new RiakMapReduceQuery()
                 .Inputs(input);
 
+            var lastLink = riakLinks.Last();
+
             foreach(var riakLink in riakLinks)
             {
                 var link = riakLink;
-                var keep = link == riakLinks.Last();
+                var keep = link == lastLink;
 
                 query.Link(l => l.FromRiakLink(link).Keep(keep));
             }


### PR DESCRIPTION
Moved riakLinks.Last() call outside of foreach to prevent multiple calls to .Last().

Fixes #90
