### PR TITLE
Fix up Map/Reduce input API issues - #120

### DIFF
--- a/CorrugatedIron.Tests.Live/LoadTests.cs
+++ b/CorrugatedIron.Tests.Live/LoadTests.cs
@@ -64,7 +64,7 @@ namespace CorrugatedIron.Tests.Live.LoadTests
             }
 
             var input = new RiakBucketKeyInput();
-            keys.ForEach(k => input.AddBucketKey(MapReduceBucket, k));
+            keys.ForEach(k => input.Add(MapReduceBucket, k));
 
             var query = new RiakMapReduceQuery()
                 .Inputs(input)
@@ -123,7 +123,7 @@ namespace CorrugatedIron.Tests.Live.LoadTests
             }
 
             var input = new RiakBucketKeyInput();
-            keys.ForEach(k => input.AddBucketKey(MapReduceBucket, k));
+            keys.ForEach(k => input.Add(MapReduceBucket, k));
 
             var query = new RiakMapReduceQuery()
                 .Inputs(input)

--- a/CorrugatedIron.Tests.Live/RiakObjectTests.cs
+++ b/CorrugatedIron.Tests.Live/RiakObjectTests.cs
@@ -161,8 +161,8 @@ namespace CorrugatedIron.Tests.Live
             var jeremiah = Client.Get(TestBucket, Jeremiah).Value;
             var jLinks = jeremiah.Links;
 
-            var input = new RiakBucketKeyInput();
-            input.AddBucketKey(TestBucket, Jeremiah);
+            var input = new RiakBucketKeyInput()
+                .Add(TestBucket, Jeremiah);
 
             var query = new RiakMapReduceQuery()
                 .Inputs(input)
@@ -256,7 +256,6 @@ namespace CorrugatedIron.Tests.Live
 				RiakLink.AllLinks,
 				RiakLink.AllLinks
 			};
-
 
             var linkPeople = Client.WalkLinks(oj, linkPhases);
             linkPeople.IsSuccess.ShouldBeTrue();

--- a/CorrugatedIron.Tests/CorrugatedIron.Tests.csproj
+++ b/CorrugatedIron.Tests/CorrugatedIron.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Comms\RoundRobinStrategyTests.cs" />
     <Compile Include="Json\RiakObjectConversionTests.cs" />
     <Compile Include="Json\TestObjects.cs" />
+    <Compile Include="Models\MapReduce\RiakMapReduceInputSerialisationTests.cs" />
     <Compile Include="Models\RiakBucketPropertyTests.cs" />
     <Compile Include="RiakAsyncClientTests.cs" />
     <Compile Include="RiakClientSetBucketPropertiesTests.cs" />

--- a/CorrugatedIron.Tests/Models/MapReduce/RiakMapReduceInputSerialisationTests.cs
+++ b/CorrugatedIron.Tests/Models/MapReduce/RiakMapReduceInputSerialisationTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) 2013 - OJ Reeves & Jeremiah Peschka
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using System.Text;
+using CorrugatedIron.Models.MapReduce.Inputs;
+using NUnit.Framework;
+using Newtonsoft.Json;
+
+namespace CorrugatedIron.Tests.Models.MapReduce
+{
+    [TestFixture]
+    public class RiakMapReduceInputSerialisationTests
+    {
+        private static string Serialize(Func<JsonWriter, JsonWriter> doWrite)
+        {
+            var sb = new StringBuilder();
+
+            using(var sw = new StringWriter(sb))
+            using(JsonWriter writer = new JsonTextWriter(sw))
+            {
+                doWrite(writer);
+            }
+
+            return sb.ToString();
+        }
+
+        [Test]
+        public void RiakBucketKeyInputSeralisesCorrectly()
+        {
+            var input = new RiakBucketKeyInput()
+                .Add("foo", "bar")
+                .Add("foo", "baz")
+                .Add("dooby", "scooby");
+
+            var s = Serialize(input.WriteJson);
+
+            Assert.AreEqual(s, "\"inputs\":[[\"foo\",\"bar\"],[\"foo\",\"baz\"],[\"dooby\",\"scooby\"]]");
+        }
+
+        [Test]
+        public void RiakBucketKeyKeyDataInputSeralisesCorrectly()
+        {
+            var input = new RiakBucketKeyKeyDataInput()
+                .Add("foo", "bar", "baz")
+                .Add("foo", "baz", 130)
+                .Add("dooby", "scooby", new { la = "ding", ray = "me", wit = 0 });
+
+            var s = Serialize(input.WriteJson);
+
+            Assert.AreEqual(s, "\"inputs\":[[\"foo\",\"bar\",\"baz\"],[\"foo\",\"baz\",130],[\"dooby\",\"scooby\",{\"la\":\"ding\",\"ray\":\"me\",\"wit\":0}]]");
+        }
+    }
+}

--- a/CorrugatedIron/Models/MapReduce/Inputs/RiakBucketKeyInput.cs
+++ b/CorrugatedIron/Models/MapReduce/Inputs/RiakBucketKeyInput.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
+﻿// Copyright (c) 2013 - OJ Reeves & Jeremiah Peschka
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file
@@ -17,6 +17,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CorrugatedIron.Models.MapReduce.Inputs
 {
@@ -29,9 +30,40 @@ namespace CorrugatedIron.Models.MapReduce.Inputs
             BucketKeyList = new List<Tuple<string, string>>();
         }
 
-        public void AddBucketKey(string bucket, string key)
+        public RiakBucketKeyInput Add(string bucket, string key)
         {
-            BucketKeyList.Add(new Tuple<string, string>(bucket, key));
+            BucketKeyList.Add(Tuple.Create(bucket, key));
+            return this;
+        }
+
+        public RiakBucketKeyInput Add(RiakObjectId objectId)
+        {
+            BucketKeyList.Add(Tuple.Create(objectId.Bucket, objectId.Key));
+            return this;
+        }
+
+        public RiakBucketKeyInput Add(params RiakObjectId[] objectIds)
+        {
+            BucketKeyList.AddRange(objectIds.Select(o => Tuple.Create(o.Bucket, o.Key)));
+            return this;
+        }
+
+        public RiakBucketKeyInput Add(IEnumerable<RiakObjectId> objectIds)
+        {
+            BucketKeyList.AddRange(objectIds.Select(o => Tuple.Create(o.Bucket, o.Key)));
+            return this;
+        }
+
+        public RiakBucketKeyInput Add(params Tuple<string, string>[] pairs)
+        {
+            BucketKeyList.AddRange(pairs);
+            return this;
+        }
+
+        public RiakBucketKeyInput Add(IEnumerable<Tuple<string, string>> pairs)
+        {
+            BucketKeyList.AddRange(pairs);
+            return this;
         }
 
         public override JsonWriter WriteJson(JsonWriter writer)
@@ -55,12 +87,7 @@ namespace CorrugatedIron.Models.MapReduce.Inputs
         public static RiakBucketKeyInput FromRiakObjectIds(IEnumerable<RiakObjectId> riakObjectIds)
         {
             var rbki = new RiakBucketKeyInput();
-            
-            foreach(var objectid in riakObjectIds)
-            {
-                rbki.AddBucketKey(objectid.Bucket, objectid.Key);
-            }
-            
+            rbki.Add(riakObjectIds);
             return rbki;
         }
     }

--- a/CorrugatedIron/Models/MapReduce/Inputs/RiakBucketKeyKeyDataInput.cs
+++ b/CorrugatedIron/Models/MapReduce/Inputs/RiakBucketKeyKeyDataInput.cs
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System.Linq;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -29,9 +30,22 @@ namespace CorrugatedIron.Models.MapReduce.Inputs
             BucketKeyKeyData = new List<Tuple<string, string, object>>();
         }
 
-        public void AddBucketKeyKeyData(string bucket, string key, object keyData)
+        public RiakBucketKeyKeyDataInput Add(string bucket, string key, object keyData)
         {
             BucketKeyKeyData.Add(new Tuple<string, string, object>(bucket, key, keyData));
+            return this;
+        }
+
+        public RiakBucketKeyKeyDataInput Add(params Tuple<string, string, object>[] pairs)
+        {
+            BucketKeyKeyData.AddRange(pairs);
+            return this;
+        }
+
+        public RiakBucketKeyKeyDataInput Add(IEnumerable<Tuple<string, string, object>> pairs)
+        {
+            BucketKeyKeyData.AddRange(pairs);
+            return this;
         }
 
         public override JsonWriter WriteJson(JsonWriter writer)
@@ -39,11 +53,15 @@ namespace CorrugatedIron.Models.MapReduce.Inputs
             writer.WritePropertyName("inputs");
             writer.WriteStartArray();
 
+            var s = new JsonSerializer();
+
             BucketKeyKeyData.ForEach(bkkd =>
             {
-                writer.WriteRawValue(bkkd.Item1);
-                writer.WriteRawValue(bkkd.Item2);
-                writer.WriteRawValue(bkkd.Item3.ToString());
+                writer.WriteStartArray();
+                writer.WriteValue(bkkd.Item1);
+                writer.WriteValue(bkkd.Item2);
+                s.Serialize(writer, bkkd.Item3);
+                writer.WriteEndArray();
             });
 
             writer.WriteEndArray();

--- a/CorrugatedIron/RiakClient.cs
+++ b/CorrugatedIron/RiakClient.cs
@@ -831,8 +831,8 @@ namespace CorrugatedIron
         {
             System.Diagnostics.Debug.Assert(riakLinks.Count > 0, "Link walking requires at least one link");
 
-            var input = new RiakBucketKeyInput();
-            input.AddBucketKey(riakObject.Bucket, riakObject.Key);
+            var input = new RiakBucketKeyInput()
+                .Add(riakObject.Bucket, riakObject.Key);
 
             var query = new RiakMapReduceQuery()
                 .Inputs(input);

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,10 @@ Release Notes
 
 * Enabled the setting of Vector Clock values via an explicit interface implementation. The property was not made writeable as it wasn't something that we felt that most users should use. Casting a `RiakObject` to an `IWriteableVclock` interface allows the Vclock to be set.
 
+### Fixes
+
+* [Issue 120](https://github.com/DistributedNonsense/CorrugatedIron/issues/120) - Update both `RiakBucketKeyInput` and `RiakBucketKeyKeyDataInput` classes so that their APIs are a little nicer to use. This also results in a bug fix in `RiakBucketKeyKeyDataInput` where the serialisation was (rather horribly) incorrect.
+
 v1.3.1
 ------
 


### PR DESCRIPTION
Fix up the API of the two input classes which were not nice to use. Also
fix up the serialisation problems that were found while doing this work.
The class should be easier to use now and be more in line with what we do
elsewhere in the library.
