### PR TITLE
Added Delete(RiakObject) to IRiakClient

### DIFF
--- a/CorrugatedIron/IRiakBatchClient.cs
+++ b/CorrugatedIron/IRiakBatchClient.cs
@@ -39,6 +39,7 @@ namespace CorrugatedIron
         RiakResult<RiakObject> Put(RiakObject value, RiakPutOptions options = null);
         IEnumerable<RiakResult<RiakObject>> Put(IEnumerable<RiakObject> values, RiakPutOptions options = null);
 
+        RiakResult Delete(RiakObject riakObject, RiakDeleteOptions options = null);
         RiakResult Delete(string bucket, string key, RiakDeleteOptions options = null);
         RiakResult Delete(RiakObjectId objectId, RiakDeleteOptions options = null);
         IEnumerable<RiakResult> Delete(IEnumerable<RiakObjectId> objectIds, RiakDeleteOptions options = null);

--- a/CorrugatedIron/RiakAsyncClient.cs
+++ b/CorrugatedIron/RiakAsyncClient.cs
@@ -40,6 +40,7 @@ namespace CorrugatedIron
         Task<RiakResult<RiakObject>> Put(RiakObject value, RiakPutOptions options = null);
         Task<IEnumerable<RiakResult<RiakObject>>> Put(IEnumerable<RiakObject> values, RiakPutOptions options = null);
 
+        Task<RiakResult> Delete(RiakObject riakObject, RiakDeleteOptions options = null);
         Task<RiakResult> Delete(string bucket, string key, RiakDeleteOptions options = null);
         Task<RiakResult> Delete(RiakObjectId objectId, RiakDeleteOptions options = null);
         Task<IEnumerable<RiakResult>> Delete(IEnumerable<RiakObjectId> objectIds, RiakDeleteOptions options = null);
@@ -176,6 +177,11 @@ namespace CorrugatedIron
         public Task<RiakResult<RiakObject>> Put(RiakObject value, RiakPutOptions options)
         {
             return Task.Factory.StartNew(() => _client.Put(value, options));
+        }
+
+        public Task<RiakResult> Delete(RiakObject riakObject, RiakDeleteOptions options = null)
+        {
+            return Task.Factory.StartNew(() => _client.Delete(riakObject, options));
         }
 
         public Task<RiakResult> Delete(string bucket, string key, RiakDeleteOptions options = null)

--- a/CorrugatedIron/RiakClient.cs
+++ b/CorrugatedIron/RiakClient.cs
@@ -469,6 +469,17 @@ namespace CorrugatedIron
         }
 
         /// <summary>
+        /// Delete the data identified by the <paramref name="riakObject"/>
+        /// </summary>
+        /// <param name='riakObject'>
+        /// The object to delete
+        /// </param>
+        public RiakResult Delete(RiakObject riakObject, RiakDeleteOptions options = null)
+        {
+            return Delete(riakObject.Bucket, riakObject.Key, options);
+        }
+
+        /// <summary>
         /// Delete the record identified by <paramref name="key"/> from a <paramref name="bucket"/>.
         /// </summary>
         /// <param name='bucket'>


### PR DESCRIPTION
It's now possible to delete an object from Riak in just about any way that you can imagine. This gives the API a little bit more flexibility and requires that users jump through fewer hoops in order to delete an object from Riak.
