### PR TITLE
Simple fix for protocol buffer RpbBucketProps

### DIFF
--- a/CorrugatedIron/Messages/riak.cs
+++ b/CorrugatedIron/Messages/riak.cs
@@ -749,7 +749,7 @@ namespace CorrugatedIron.Messages
     [global::ProtoBuf.ProtoMember(24, IsRequired = false, Name=@"repl", DataFormat = global::ProtoBuf.DataFormat.TwosComplement)]
     public RpbBucketProps.RpbReplMode repl
     {
-      get { return _repl.Value; }
+      get { return _repl.HasValue ? _repl.Value : RpbReplMode.FALSE; }
       set { _repl = value; }
     }
     [global::System.Xml.Serialization.XmlIgnore]


### PR DESCRIPTION
In Riak 2.0.0 pre5, I've noticed that the repl (replication) flag can be null. The way protocol buffer's generated the C# code does not correctly handle this case. Here's a really simple, minor fix that works. It may be undesirable given that it sets replication to false by default in the absence of a value but I didn't feel comfortable changing it to anything else given it could have very unexpected side-effects. In this case, the user is required to configure the bucket, but I don't see the harm in that... (he said naively)
