### PR TITLE
Use Limited ReceiveTimeout, Correct Duplicate Protobuf Field Index on IndexReq

### DIFF
--- a/CorrugatedIron/Comms/RiakPbcSocket.cs
+++ b/CorrugatedIron/Comms/RiakPbcSocket.cs
@@ -229,7 +229,6 @@ namespace CorrugatedIron.Comms
 
         private byte[] ReceiveAll(byte[] resultBuffer)
         {
-            PbcSocket.ReceiveTimeout = 0;
             int totalBytesReceived = 0;
             int lengthToReceive = resultBuffer.Length;
             while(lengthToReceive > 0)

--- a/CorrugatedIron/Messages/riak_kv.cs
+++ b/CorrugatedIron/Messages/riak_kv.cs
@@ -824,7 +824,7 @@ namespace CorrugatedIron.Messages
         }
 
         private byte[] _pagination_sort = null;
-        [global::ProtoBuf.ProtoMember(13, IsRequired = false, Name="@pagination_sort", DataFormat =  global::ProtoBuf.DataFormat.Default)]
+        [global::ProtoBuf.ProtoMember(14, IsRequired = false, Name="@pagination_sort", DataFormat =  global::ProtoBuf.DataFormat.Default)]
         [global::System.ComponentModel.DefaultValue(null)]
         public byte[] pagination_sort
         {


### PR DESCRIPTION
Repair incorrect index on RpbIndexReq field. Change Remove line from RpbSocket causing ReceiveAll to wait indefinitely on a response and use the specified receive timeout.
