### PR TITLE
Fix TravisCI "false negative" builds

### DIFF
--- a/.travis/RunBuild.sh
+++ b/.travis/RunBuild.sh
@@ -3,6 +3,7 @@
 DIR=`dirname $0`
 cd ${DIR}/..
 make debug
-echo "Make result: $?"
-exit $?
+rc=$?
+echo "Make result: $rc"
+exit $rc
 


### PR DESCRIPTION
Fixes issue #194 (see that for more info).  Will fail the TravisCI build if msbuild fails.  
See https://travis-ci.org/alexmoore/CorrugatedIron/builds for "tests", build 3 is the first build that failed correctly.  Builds 1,2,4,5 were setup or reverts. 
