### PR TITLE
Ready: Ensure .ForEach was removed.

### DIFF
--- a/src/RiakClient/Extensions/JsonExtensions.cs
+++ b/src/RiakClient/Extensions/JsonExtensions.cs
@@ -19,6 +19,8 @@
 
 namespace RiakClient.Extensions
 {
+    using System.Collections.Generic;
+    using Models.MapReduce.KeyFilters;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -120,6 +122,15 @@ namespace RiakClient.Extensions
             }
 
             return writer;
+        }
+
+        internal static void WriteRawFilterTokenArray(this JsonWriter writer, List<IRiakKeyFilterToken> tokens)
+        {
+            writer.WriteStartArray();
+
+            tokens.ForEach(t => writer.WriteRawValue(t.ToString()));
+
+            writer.WriteEndArray();
         }
     }
 }

--- a/src/RiakClient/Models/MapReduce/KeyFilters/And.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/And.cs
@@ -23,6 +23,7 @@ namespace RiakClient.Models.MapReduce.KeyFilters
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using Extensions;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -85,27 +86,21 @@ namespace RiakClient.Models.MapReduce.KeyFilters
         public string ToJsonString()
         {
             var sb = new StringBuilder();
-
-            using (var sw = new StringWriter(sb))
+            var sw = new StringWriter(sb);
+            
+            using (JsonWriter jw = new JsonTextWriter(sw))
             {
-                using (JsonWriter jw = new JsonTextWriter(sw))
-                {
-                    jw.WriteStartArray();
+                jw.WriteStartArray();
 
-                    jw.WriteValue(FunctionName);
+                jw.WriteValue(FunctionName);
 
-                    jw.WriteStartArray();
-                    Left.ForEach(l => jw.WriteRawValue(l.ToString()));
-                    jw.WriteEndArray();
+                jw.WriteRawFilterTokenArray(Left);
 
-                    jw.WriteStartArray();
-                    Right.ForEach(r => jw.WriteRawValue(r.ToString()));
-                    jw.WriteEndArray();
+                jw.WriteRawFilterTokenArray(Right);
 
-                    jw.WriteEndArray();
-                }
+                jw.WriteEndArray();
             }
-
+            
             return sb.ToString();
         }
     }

--- a/src/RiakClient/Models/MapReduce/KeyFilters/And.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/And.cs
@@ -85,9 +85,12 @@ namespace RiakClient.Models.MapReduce.KeyFilters
         /// <returns>JSON representation of the <see cref="And"/> class</returns>
         public string ToJsonString()
         {
+            /*
+             * NB: JsonTextWriter is guaranteed to close the StringWriter
+             * https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/JsonTextWriter.cs#L150-L160
+             */
             var sb = new StringBuilder();
             var sw = new StringWriter(sb);
-            
             using (JsonWriter jw = new JsonTextWriter(sw))
             {
                 jw.WriteStartArray();

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Not.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Not.cs
@@ -23,6 +23,7 @@ namespace RiakClient.Models.MapReduce.KeyFilters
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using Extensions;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -55,21 +56,17 @@ namespace RiakClient.Models.MapReduce.KeyFilters
         public string ToJsonString()
         {
             var sb = new StringBuilder();
-
-            using (var sw = new StringWriter(sb))
+            var sw = new StringWriter(sb);
+            
+            using (JsonWriter jw = new JsonTextWriter(sw))
             {
-                using (JsonWriter jw = new JsonTextWriter(sw))
-                {
-                    jw.WriteStartArray();
+                jw.WriteStartArray();
 
-                    jw.WriteValue(FunctionName);
-                    jw.WriteStartArray();
+                jw.WriteValue(FunctionName);
 
-                    Argument.ForEach(a => jw.WriteRawValue(a.ToString()));
+                jw.WriteRawFilterTokenArray(Argument);
 
-                    jw.WriteEndArray();
-                    jw.WriteEndArray();
-                }
+                jw.WriteEndArray();
             }
 
             return sb.ToString();

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Not.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Not.cs
@@ -55,9 +55,12 @@ namespace RiakClient.Models.MapReduce.KeyFilters
 
         public string ToJsonString()
         {
+            /*
+             * NB: JsonTextWriter is guaranteed to close the StringWriter
+             * https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/JsonTextWriter.cs#L150-L160
+             */
             var sb = new StringBuilder();
             var sw = new StringWriter(sb);
-            
             using (JsonWriter jw = new JsonTextWriter(sw))
             {
                 jw.WriteStartArray();

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Or.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Or.cs
@@ -60,9 +60,12 @@ namespace RiakClient.Models.MapReduce.KeyFilters
 
         public string ToJsonString()
         {
+            /*
+             * NB: JsonTextWriter is guaranteed to close the StringWriter
+             * https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/JsonTextWriter.cs#L150-L160
+             */
             var sb = new StringBuilder();
             var sw = new StringWriter(sb);
-            
             using (JsonWriter jw = new JsonTextWriter(sw))
             {
                 jw.WriteStartArray();

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Or.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Or.cs
@@ -23,6 +23,7 @@ namespace RiakClient.Models.MapReduce.KeyFilters
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using Extensions;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -60,25 +61,19 @@ namespace RiakClient.Models.MapReduce.KeyFilters
         public string ToJsonString()
         {
             var sb = new StringBuilder();
-
-            using (var sw = new StringWriter(sb))
+            var sw = new StringWriter(sb);
+            
+            using (JsonWriter jw = new JsonTextWriter(sw))
             {
-                using (JsonWriter jw = new JsonTextWriter(sw))
-                {
-                    jw.WriteStartArray();
+                jw.WriteStartArray();
 
-                    jw.WriteValue(FunctionName);
+                jw.WriteValue(FunctionName);
 
-                    jw.WriteStartArray();
-                    Left.ForEach(l => jw.WriteRawValue(l.ToString()));
-                    jw.WriteEndArray();
+                jw.WriteRawFilterTokenArray(Left);
 
-                    jw.WriteStartArray();
-                    Right.ForEach(r => jw.WriteRawValue(r.ToString()));
-                    jw.WriteEndArray();
+                jw.WriteRawFilterTokenArray(Right);
 
-                    jw.WriteEndArray();
-                }
+                jw.WriteEndArray();
             }
 
             return sb.ToString();

--- a/src/RiakClient/Models/MapReduce/KeyFilters/SetMember.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/SetMember.cs
@@ -60,22 +60,23 @@ namespace RiakClient.Models.MapReduce.KeyFilters
 
         public string ToJsonString()
         {
+            /*
+             * NB: JsonTextWriter is guaranteed to close the StringWriter
+             * https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/JsonTextWriter.cs#L150-L160
+             */
             var sb = new StringBuilder();
-
-            using (var sw = new StringWriter(sb))
+            var sw = new StringWriter(sb);
+            using (JsonWriter jw = new JsonTextWriter(sw))
             {
-                using (JsonWriter jw = new JsonTextWriter(sw))
-                {
-                    jw.WriteStartArray();
+                jw.WriteStartArray();
 
-                    jw.WriteValue(FunctionName);
+                jw.WriteValue(FunctionName);
 
-                    Set.ForEach(v => jw.WriteValue(v));
+                Set.ForEach(v => jw.WriteValue(v));
 
-                    jw.WriteEndArray();
-                }
+                jw.WriteEndArray();
             }
-
+            
             return sb.ToString();
         }
     }


### PR DESCRIPTION
Remaining .ForEach were List.ForEach, not the weird IEnumerable.ForEach.

Removed some duplication I found, and normalized the usage of double usings in the Models.MapReduce.KeyFilters namespace.