### PR TITLE
Redundant copyright is redundant.

### DIFF
--- a/src/RiakClient/Auth/RiakSecurityManager.cs
+++ b/src/RiakClient/Auth/RiakSecurityManager.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSecurityManager.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/IRiakConnection.cs
+++ b/src/RiakClient/Comms/IRiakConnection.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakConnection.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/IRiakConnectionFactory.cs
+++ b/src/RiakClient/Comms/IRiakConnectionFactory.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakConnectionFactory.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/IRiakConnectionManager.cs
+++ b/src/RiakClient/Comms/IRiakConnectionManager.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakConnectionManager.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/IRiakNode.cs
+++ b/src/RiakClient/Comms/IRiakNode.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakNode.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/LoadBalancing/ILoadBalancingStrategy.cs
+++ b/src/RiakClient/Comms/LoadBalancing/ILoadBalancingStrategy.cs
@@ -1,6 +1,6 @@
 // <copyright file="ILoadBalancingStrategy.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/LoadBalancing/RoundRobinStrategy.cs
+++ b/src/RiakClient/Comms/LoadBalancing/RoundRobinStrategy.cs
@@ -1,6 +1,6 @@
 // <copyright file="RoundRobinStrategy.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/RiakConnection.cs
+++ b/src/RiakClient/Comms/RiakConnection.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakConnection.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/RiakConnectionFactory.cs
+++ b/src/RiakClient/Comms/RiakConnectionFactory.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakConnectionFactory.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/RiakConnectionPool.cs
+++ b/src/RiakClient/Comms/RiakConnectionPool.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakConnectionPool.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/RiakNode.cs
+++ b/src/RiakClient/Comms/RiakNode.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakNode.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/RiakOnTheFlyConnection.cs
+++ b/src/RiakClient/Comms/RiakOnTheFlyConnection.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakOnTheFlyConnection.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Comms/RiakPbcSocket.cs
+++ b/src/RiakClient/Comms/RiakPbcSocket.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakPbcSocket.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/IRiakAuthenticationConfiguration.cs
+++ b/src/RiakClient/Config/IRiakAuthenticationConfiguration.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakAuthenticationConfiguration.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/IRiakClusterConfiguration.cs
+++ b/src/RiakClient/Config/IRiakClusterConfiguration.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakClusterConfiguration.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/IRiakNodeConfiguration.cs
+++ b/src/RiakClient/Config/IRiakNodeConfiguration.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakNodeConfiguration.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/RiakAuthenticationConfiguration.cs
+++ b/src/RiakClient/Config/RiakAuthenticationConfiguration.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakAuthenticationConfiguration.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/RiakClusterConfiguration.cs
+++ b/src/RiakClient/Config/RiakClusterConfiguration.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakClusterConfiguration.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/RiakNodeConfiguration.cs
+++ b/src/RiakClient/Config/RiakNodeConfiguration.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakNodeConfiguration.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Config/RiakNodeConfigurationCollection.cs
+++ b/src/RiakClient/Config/RiakNodeConfigurationCollection.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakNodeConfigurationCollection.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Containers/ConcurrentEnumerable.cs
+++ b/src/RiakClient/Containers/ConcurrentEnumerable.cs
@@ -1,6 +1,6 @@
 // <copyright file="ConcurrentEnumerable.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Containers/ConcurrentEnumerator.cs
+++ b/src/RiakClient/Containers/ConcurrentEnumerator.cs
@@ -1,6 +1,6 @@
 // <copyright file="ConcurrentEnumerator.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Containers/IConcurrentEnumerable.cs
+++ b/src/RiakClient/Containers/IConcurrentEnumerable.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="IConcurrentEnumerable.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Containers/IConcurrentEnumerator.cs
+++ b/src/RiakClient/Containers/IConcurrentEnumerator.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="IConcurrentEnumerator.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Converters/RiakObjectIdConverter.cs
+++ b/src/RiakClient/Converters/RiakObjectIdConverter.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakObjectIdConverter.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Exceptions/RiakException.cs
+++ b/src/RiakClient/Exceptions/RiakException.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakException.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Exceptions/RiakInvalidDataException.cs
+++ b/src/RiakClient/Exceptions/RiakInvalidDataException.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakInvalidDataException.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Exceptions/RiakUnsupportedException.cs
+++ b/src/RiakClient/Exceptions/RiakUnsupportedException.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="RiakUnsupportedException.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Extensions/EnumerableExtensions.cs
+++ b/src/RiakClient/Extensions/EnumerableExtensions.cs
@@ -1,6 +1,6 @@
 // <copyright file="EnumerableExtensions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Extensions/JsonExtensions.cs
+++ b/src/RiakClient/Extensions/JsonExtensions.cs
@@ -1,6 +1,6 @@
 // <copyright file="JsonExtensions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Extensions/StringExtensions.cs
+++ b/src/RiakClient/Extensions/StringExtensions.cs
@@ -1,6 +1,6 @@
 // <copyright file="StringExtensions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/IRiakAsyncClient.cs
+++ b/src/RiakClient/IRiakAsyncClient.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="IRiakAsyncClient.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/IRiakBatchClient.cs
+++ b/src/RiakClient/IRiakBatchClient.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakBatchClient.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/IRiakClient.cs
+++ b/src/RiakClient/IRiakClient.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="IRiakClient.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/IRiakEndPoint.cs
+++ b/src/RiakClient/IRiakEndPoint.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakEndPoint.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/MessageCode.cs
+++ b/src/RiakClient/Messages/MessageCode.cs
@@ -1,6 +1,6 @@
 // <copyright file="MessageCode.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/MessageCodeTypeMapBuilder.cs
+++ b/src/RiakClient/Messages/MessageCodeTypeMapBuilder.cs
@@ -1,6 +1,6 @@
 // <copyright file="MessageCodeTypeMapBuilder.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/RpbClasses.cs
+++ b/src/RiakClient/Messages/RpbClasses.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RpbClasses.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/riak.cs
+++ b/src/RiakClient/Messages/riak.cs
@@ -1,6 +1,6 @@
 // <copyright file="riak.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/riak_dt.cs
+++ b/src/RiakClient/Messages/riak_dt.cs
@@ -1,6 +1,6 @@
 // <copyright file="riak_dt.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/riak_kv.cs
+++ b/src/RiakClient/Messages/riak_kv.cs
@@ -1,6 +1,6 @@
 // <copyright file="riak_kv.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/riak_search.cs
+++ b/src/RiakClient/Messages/riak_search.cs
@@ -1,6 +1,6 @@
 // <copyright file="riak_search.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Messages/riak_yokozuna.cs
+++ b/src/RiakClient/Messages/riak_yokozuna.cs
@@ -1,6 +1,6 @@
 // <copyright file="riak_yokozuna.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/CommitHook/IRiakCommitHook.cs
+++ b/src/RiakClient/Models/CommitHook/IRiakCommitHook.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakCommitHook.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/CommitHook/IRiakPostCommitHook.cs
+++ b/src/RiakClient/Models/CommitHook/IRiakPostCommitHook.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakPostCommitHook.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/CommitHook/IRiakPreCommitHook.cs
+++ b/src/RiakClient/Models/CommitHook/IRiakPreCommitHook.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakPreCommitHook.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/CommitHook/RiakCommitHook.cs
+++ b/src/RiakClient/Models/CommitHook/RiakCommitHook.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakCommitHook.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/CommitHook/RiakErlangCommitHook.cs
+++ b/src/RiakClient/Models/CommitHook/RiakErlangCommitHook.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakErlangCommitHook.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/CommitHook/RiakJavascriptCommitHook.cs
+++ b/src/RiakClient/Models/CommitHook/RiakJavascriptCommitHook.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakJavascriptCommitHook.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/IWriteableVClock.cs
+++ b/src/RiakClient/Models/IWriteableVClock.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="IWriteableVClock.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/BinIndex.cs
+++ b/src/RiakClient/Models/Index/BinIndex.cs
@@ -1,6 +1,6 @@
 // <copyright file="BinIndex.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/IRiakIndexResult.cs
+++ b/src/RiakClient/Models/Index/IRiakIndexResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakIndexResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/IntIndex.cs
+++ b/src/RiakClient/Models/Index/IntIndex.cs
@@ -1,6 +1,6 @@
 // <copyright file="IntIndex.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/RiakIndexKeyTerm.cs
+++ b/src/RiakClient/Models/Index/RiakIndexKeyTerm.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexKeyTerm.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/RiakIndexResult.cs
+++ b/src/RiakClient/Models/Index/RiakIndexResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/RiakStreamedIndexResult.cs
+++ b/src/RiakClient/Models/Index/RiakStreamedIndexResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakStreamedIndexResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Index/SecondaryIndex.cs
+++ b/src/RiakClient/Models/Index/SecondaryIndex.cs
@@ -1,6 +1,6 @@
 // <copyright file="SecondaryIndex.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Fluent/RiakFluentActionPhaseErlang.cs
+++ b/src/RiakClient/Models/MapReduce/Fluent/RiakFluentActionPhaseErlang.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakFluentActionPhaseErlang.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Fluent/RiakFluentActionPhaseJavascript.cs
+++ b/src/RiakClient/Models/MapReduce/Fluent/RiakFluentActionPhaseJavascript.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakFluentActionPhaseJavascript.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Fluent/RiakFluentKeyFilter.cs
+++ b/src/RiakClient/Models/MapReduce/Fluent/RiakFluentKeyFilter.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakFluentKeyFilter.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Fluent/RiakFluentLinkPhase.cs
+++ b/src/RiakClient/Models/MapReduce/Fluent/RiakFluentLinkPhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakFluentLinkPhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/IRiakMapReduceResult.cs
+++ b/src/RiakClient/Models/MapReduce/IRiakMapReduceResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakMapReduceResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/IRiakPhaseInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/IRiakPhaseInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakPhaseInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakBinIndexEqualityInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakBinIndexEqualityInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBinIndexEqualityInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakBinIndexRangeInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakBinIndexRangeInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBinIndexRangeInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakBucketInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakBucketInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBucketInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakBucketKeyInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakBucketKeyInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBucketKeyInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakBucketKeyKeyDataInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakBucketKeyKeyDataInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBucketKeyKeyDataInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakBucketSearchInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakBucketSearchInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBucketSearchInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakIndex.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakIndex.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndex.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakIndexInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakIndexInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakIntIndexEqualityInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakIntIndexEqualityInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIntIndexEqualityInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakIntIndexRangeInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakIntIndexRangeInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIntIndexRangeInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakModuleFunctionArgInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakModuleFunctionArgInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakModuleFunctionArgInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Inputs/RiakSearchInput.cs
+++ b/src/RiakClient/Models/MapReduce/Inputs/RiakSearchInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/And.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/And.cs
@@ -1,6 +1,6 @@
 // <copyright file="And.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Between.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Between.cs
@@ -1,6 +1,6 @@
 // <copyright file="Between.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/EndsWith.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/EndsWith.cs
@@ -1,6 +1,6 @@
 // <copyright file="EndsWith.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Equal.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Equal.cs
@@ -1,6 +1,6 @@
 // <copyright file="Equal.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/FloatToString.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/FloatToString.cs
@@ -1,6 +1,6 @@
 // <copyright file="FloatToString.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/GreaterThan.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/GreaterThan.cs
@@ -1,6 +1,6 @@
 // <copyright file="GreaterThan.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/GreaterThanOrEqualTo.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/GreaterThanOrEqualTo.cs
@@ -1,6 +1,6 @@
 // <copyright file="GreaterThanOrEqualTo.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/IRiakKeyFilterToken.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/IRiakKeyFilterToken.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakKeyFilterToken.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/IntToString.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/IntToString.cs
@@ -1,6 +1,6 @@
 // <copyright file="IntToString.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/LessThan.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/LessThan.cs
@@ -1,6 +1,6 @@
 // <copyright file="LessThan.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/LessThanOrEqualTo.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/LessThanOrEqualTo.cs
@@ -1,6 +1,6 @@
 // <copyright file="LessThanOrEqualTo.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Matches.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Matches.cs
@@ -1,6 +1,6 @@
 // <copyright file="Matches.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Not.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Not.cs
@@ -1,6 +1,6 @@
 // <copyright file="Not.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/NotEqual.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/NotEqual.cs
@@ -1,6 +1,6 @@
 // <copyright file="NotEqual.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Or.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Or.cs
@@ -1,6 +1,6 @@
 // <copyright file="Or.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/RiakCompositeKeyFilterToken.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/RiakCompositeKeyFilterToken.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakCompositeKeyFilterToken.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/RiakKeyFilterToken.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/RiakKeyFilterToken.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakKeyFilterToken.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/SetMember.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/SetMember.cs
@@ -1,6 +1,6 @@
 // <copyright file="SetMember.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/SimilarTo.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/SimilarTo.cs
@@ -1,6 +1,6 @@
 // <copyright file="SimilarTo.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/StartsWith.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/StartsWith.cs
@@ -1,6 +1,6 @@
 // <copyright file="StartsWith.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/StringToFloat.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/StringToFloat.cs
@@ -1,6 +1,6 @@
 // <copyright file="StringToFloat.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/StringToInt.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/StringToInt.cs
@@ -1,6 +1,6 @@
 // <copyright file="StringToInt.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/ToLower.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/ToLower.cs
@@ -1,6 +1,6 @@
 // <copyright file="ToLower.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/ToUpper.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/ToUpper.cs
@@ -1,6 +1,6 @@
 // <copyright file="ToUpper.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/Tokenize.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/Tokenize.cs
@@ -1,6 +1,6 @@
 // <copyright file="Tokenize.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/KeyFilters/UrlDecode.cs
+++ b/src/RiakClient/Models/MapReduce/KeyFilters/UrlDecode.cs
@@ -1,6 +1,6 @@
 // <copyright file="UrlDecode.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Languages/IRiakPhaseLanguage.cs
+++ b/src/RiakClient/Models/MapReduce/Languages/IRiakPhaseLanguage.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakPhaseLanguage.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Languages/RiakPhaseLanguageErlang.cs
+++ b/src/RiakClient/Models/MapReduce/Languages/RiakPhaseLanguageErlang.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakPhaseLanguageErlang.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Languages/RiakPhaseLanguageJavascript.cs
+++ b/src/RiakClient/Models/MapReduce/Languages/RiakPhaseLanguageJavascript.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakPhaseLanguageJavascript.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Phases/RiakActionPhase.cs
+++ b/src/RiakClient/Models/MapReduce/Phases/RiakActionPhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakActionPhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Phases/RiakLinkPhase.cs
+++ b/src/RiakClient/Models/MapReduce/Phases/RiakLinkPhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakLinkPhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Phases/RiakMapPhase.cs
+++ b/src/RiakClient/Models/MapReduce/Phases/RiakMapPhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakMapPhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Phases/RiakPhase.cs
+++ b/src/RiakClient/Models/MapReduce/Phases/RiakPhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakPhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/Phases/RiakReducePhase.cs
+++ b/src/RiakClient/Models/MapReduce/Phases/RiakReducePhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakReducePhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/RiakMapReduceQuery.cs
+++ b/src/RiakClient/Models/MapReduce/RiakMapReduceQuery.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakMapReduceQuery.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/RiakMapReduceResult.cs
+++ b/src/RiakClient/Models/MapReduce/RiakMapReduceResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakMapReduceResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/RiakMapReduceResultPhase.cs
+++ b/src/RiakClient/Models/MapReduce/RiakMapReduceResultPhase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakMapReduceResultPhase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/MapReduce/RiakStreamedMapReduceResult.cs
+++ b/src/RiakClient/Models/MapReduce/RiakStreamedMapReduceResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakStreamedMapReduceResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/NVal.cs
+++ b/src/RiakClient/Models/NVal.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="NVal.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Quorum.cs
+++ b/src/RiakClient/Models/Quorum.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="Quorum.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakBinIndexId.cs
+++ b/src/RiakClient/Models/RiakBinIndexId.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="RiakBinIndexId.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakBucketProperties.cs
+++ b/src/RiakClient/Models/RiakBucketProperties.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBucketProperties.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakCounterGetOptions.cs
+++ b/src/RiakClient/Models/RiakCounterGetOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakCounterGetOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakCounterResult.cs
+++ b/src/RiakClient/Models/RiakCounterResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakCounterResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakCounterUpdateOptions.cs
+++ b/src/RiakClient/Models/RiakCounterUpdateOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakCounterUpdateOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDeleteOptions.cs
+++ b/src/RiakClient/Models/RiakDeleteOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDeleteOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/CounterOperation.cs
+++ b/src/RiakClient/Models/RiakDt/CounterOperation.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="CounterOperation.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/IDtOp.cs
+++ b/src/RiakClient/Models/RiakDt/IDtOp.cs
@@ -1,6 +1,6 @@
 // <copyright file="IDtOp.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/IRiakDtType.cs
+++ b/src/RiakClient/Models/RiakDt/IRiakDtType.cs
@@ -1,6 +1,6 @@
 // <copyright file="IRiakDtType.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/MapOperation.cs
+++ b/src/RiakClient/Models/RiakDt/MapOperation.cs
@@ -1,6 +1,6 @@
 // <copyright file="MapOperation.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/RiakDtCounter.cs
+++ b/src/RiakClient/Models/RiakDt/RiakDtCounter.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtCounter.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/RiakDtMapEntry.cs
+++ b/src/RiakClient/Models/RiakDt/RiakDtMapEntry.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtMapEntry.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/RiakDtMapField.cs
+++ b/src/RiakClient/Models/RiakDt/RiakDtMapField.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtMapField.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/RiakDtMapResult.cs
+++ b/src/RiakClient/Models/RiakDt/RiakDtMapResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtMapResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/RiakDtSetResult.cs
+++ b/src/RiakClient/Models/RiakDt/RiakDtSetResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtSetResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDt/SetOperation.cs
+++ b/src/RiakClient/Models/RiakDt/SetOperation.cs
@@ -1,6 +1,6 @@
 // <copyright file="SetOperation.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDtFetchOptions.cs
+++ b/src/RiakClient/Models/RiakDtFetchOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtFetchOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakDtUpdateOptions.cs
+++ b/src/RiakClient/Models/RiakDtUpdateOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakDtUpdateOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakGetOptions.cs
+++ b/src/RiakClient/Models/RiakGetOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakGetOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakIndexGetOptions.cs
+++ b/src/RiakClient/Models/RiakIndexGetOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexGetOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakIndexId.cs
+++ b/src/RiakClient/Models/RiakIndexId.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexId.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakIntIndexId.cs
+++ b/src/RiakClient/Models/RiakIntIndexId.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="RiakIntIndexId.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakLink.cs
+++ b/src/RiakClient/Models/RiakLink.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakLink.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakObject.cs
+++ b/src/RiakClient/Models/RiakObject.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakObject.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakObjectId.cs
+++ b/src/RiakClient/Models/RiakObjectId.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakObjectId.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakOptions.cs
+++ b/src/RiakClient/Models/RiakOptions.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RiakOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakPutOptions.cs
+++ b/src/RiakClient/Models/RiakPutOptions.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakPutOptions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/RiakServerInfo.cs
+++ b/src/RiakClient/Models/RiakServerInfo.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakServerInfo.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/BinaryTerm.cs
+++ b/src/RiakClient/Models/Search/BinaryTerm.cs
@@ -1,6 +1,6 @@
 // <copyright file="BinaryTerm.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/GroupTerm.cs
+++ b/src/RiakClient/Models/Search/GroupTerm.cs
@@ -1,6 +1,6 @@
 // <copyright file="GroupTerm.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/ProximityTerm.cs
+++ b/src/RiakClient/Models/Search/ProximityTerm.cs
@@ -1,6 +1,6 @@
 // <copyright file="ProximityTerm.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/RangeTerm.cs
+++ b/src/RiakClient/Models/Search/RangeTerm.cs
@@ -1,6 +1,6 @@
 // <copyright file="RangeTerm.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/RiakFluentSearch.cs
+++ b/src/RiakClient/Models/Search/RiakFluentSearch.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakFluentSearch.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/RiakSearchRequest.cs
+++ b/src/RiakClient/Models/Search/RiakSearchRequest.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchRequest.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/RiakSearchResult.cs
+++ b/src/RiakClient/Models/Search/RiakSearchResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/RiakSearchResultDocument.cs
+++ b/src/RiakClient/Models/Search/RiakSearchResultDocument.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchResultDocument.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/RiakSearchResultField.cs
+++ b/src/RiakClient/Models/Search/RiakSearchResultField.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchResultField.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/SearchIndex.cs
+++ b/src/RiakClient/Models/Search/SearchIndex.cs
@@ -1,6 +1,6 @@
 // <copyright file="SearchIndex.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/SearchIndexResult.cs
+++ b/src/RiakClient/Models/Search/SearchIndexResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="SearchIndexResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/SearchSchema.cs
+++ b/src/RiakClient/Models/Search/SearchSchema.cs
@@ -1,6 +1,6 @@
 // <copyright file="SearchSchema.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/Term.cs
+++ b/src/RiakClient/Models/Search/Term.cs
@@ -1,6 +1,6 @@
 // <copyright file="Term.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/Token.cs
+++ b/src/RiakClient/Models/Search/Token.cs
@@ -1,6 +1,6 @@
 // <copyright file="Token.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Models/Search/UnaryTerm.cs
+++ b/src/RiakClient/Models/Search/UnaryTerm.cs
@@ -1,6 +1,6 @@
 // <copyright file="UnaryTerm.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Properties/AssemblyInfo.cs
+++ b/src/RiakClient/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 // <copyright file="AssemblyInfo.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/ResultCode.cs
+++ b/src/RiakClient/ResultCode.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="ResultCode.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakAsyncClient.cs
+++ b/src/RiakClient/RiakAsyncClient.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakAsyncClient.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakClient.cs
+++ b/src/RiakClient/RiakClient.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakClient.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakCluster.cs
+++ b/src/RiakClient/RiakCluster.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakCluster.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakConstants.cs
+++ b/src/RiakClient/RiakConstants.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakConstants.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakEndPoint.cs
+++ b/src/RiakClient/RiakEndPoint.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakEndPoint.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakResult.cs
+++ b/src/RiakClient/RiakResult.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakResult.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/RiakResult{TResult}.cs
+++ b/src/RiakClient/RiakResult{TResult}.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakResult{TResult}.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Timeout.cs
+++ b/src/RiakClient/Timeout.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="Timeout.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Util/EnumerableUtil.cs
+++ b/src/RiakClient/Util/EnumerableUtil.cs
@@ -1,6 +1,6 @@
 // <copyright file="EnumerableUtil.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClient/Util/MonoUtil.cs
+++ b/src/RiakClient/Util/MonoUtil.cs
@@ -1,6 +1,6 @@
 // <copyright file="MonoUtil.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Advanced/BucketTypes.cs
+++ b/src/RiakClientExamples/Dev/Advanced/BucketTypes.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="BucketTypes.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Advanced/SearchSchemaExamples.cs
+++ b/src/RiakClientExamples/Dev/Advanced/SearchSchemaExamples.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="SearchSchemaExamples.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/DataModeling/DataTypes.cs
+++ b/src/RiakClientExamples/Dev/DataModeling/DataTypes.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DataTypes.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/DataModeling/EntityManager.cs
+++ b/src/RiakClientExamples/Dev/DataModeling/EntityManager.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="EntityManager.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/DataModeling/User.cs
+++ b/src/RiakClientExamples/Dev/DataModeling/User.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="User.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/DataModeling/UserRepository.cs
+++ b/src/RiakClientExamples/Dev/DataModeling/UserRepository.cs
@@ -1,5 +1,5 @@
 // <copyright file="BlogPostRepository.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/IModel.cs
+++ b/src/RiakClientExamples/Dev/IModel.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IModel.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/IRepository.cs
+++ b/src/RiakClientExamples/Dev/IRepository.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IRepository.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Repository.cs
+++ b/src/RiakClientExamples/Dev/Repository.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Repository.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Search/BlogPost.cs
+++ b/src/RiakClientExamples/Dev/Search/BlogPost.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="BlogPost.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Search/BlogPostRepository.cs
+++ b/src/RiakClientExamples/Dev/Search/BlogPostRepository.cs
@@ -1,5 +1,5 @@
 // <copyright file="BlogPostRepository.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Search/DocumentStore.cs
+++ b/src/RiakClientExamples/Dev/Search/DocumentStore.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DocumentStore.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Search/SearchDataTypes.cs
+++ b/src/RiakClientExamples/Dev/Search/SearchDataTypes.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="SearchDataTypes.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Using/Basics.cs
+++ b/src/RiakClientExamples/Dev/Using/Basics.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Basics.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Using/ConflictResolution/ResolutionExamples.cs
+++ b/src/RiakClientExamples/Dev/Using/ConflictResolution/ResolutionExamples.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ResolutionExamples.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Using/DataTypes.cs
+++ b/src/RiakClientExamples/Dev/Using/DataTypes.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="DataTypes.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Using/Search.cs
+++ b/src/RiakClientExamples/Dev/Using/Search.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Search.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Using/SecondaryIndexes.cs
+++ b/src/RiakClientExamples/Dev/Using/SecondaryIndexes.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="SecondaryIndexes.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/Dev/Using/Updates.cs
+++ b/src/RiakClientExamples/Dev/Using/Updates.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="Updates.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientExamples/ExampleBase.cs
+++ b/src/RiakClientExamples/ExampleBase.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="ExampleBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Deprecated/BucketPropertyTests.cs
+++ b/src/RiakClientTests.Deprecated/BucketPropertyTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="BucketPropertyTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Deprecated/RiakPbLegacySearchTests.cs
+++ b/src/RiakClientTests.Deprecated/RiakPbLegacySearchTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakPbLegacySearchTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Deprecated/RiakSearchMapReduceInputTests.cs
+++ b/src/RiakClientTests.Deprecated/RiakSearchMapReduceInputTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchMapReduceInputTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/BucketPropertyTests.cs
+++ b/src/RiakClientTests.Live/BucketPropertyTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="BucketPropertyTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/BucketTypeTests.cs
+++ b/src/RiakClientTests.Live/BucketTypeTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="BucketTypeTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/DataTypes/BasicMapSetDtTests.cs
+++ b/src/RiakClientTests.Live/DataTypes/BasicMapSetDtTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 - Basho Technologies, Inc.
+﻿// Copyright 2015 - Basho Technologies, Inc.
 // 
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/DataTypes/BasicSetDtTests.cs
+++ b/src/RiakClientTests.Live/DataTypes/BasicSetDtTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
+﻿// Copyright 2011 - OJ Reeves & Jeremiah Peschka
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/DataTypes/DataTypeTestsBase.cs
+++ b/src/RiakClientTests.Live/DataTypes/DataTypeTestsBase.cs
@@ -1,6 +1,6 @@
 // <copyright file="DataTypeTestsBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/DataTypes/MapDtEdgeCaseTests.cs
+++ b/src/RiakClientTests.Live/DataTypes/MapDtEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 - Basho Technologies, Inc.
+﻿// Copyright 2015 - Basho Technologies, Inc.
 // 
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/DataTypes/SetDtEdgeCaseTests.cs
+++ b/src/RiakClientTests.Live/DataTypes/SetDtEdgeCaseTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015 - Basho Technologies, Inc.
+﻿// Copyright 2015 - Basho Technologies, Inc.
 // 
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/GeneralIntegrationTests.cs
+++ b/src/RiakClientTests.Live/GeneralIntegrationTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="GeneralIntegrationTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/IdleTests.cs
+++ b/src/RiakClientTests.Live/IdleTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="IdleTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/IntegrationTestExtensions.cs
+++ b/src/RiakClientTests.Live/IntegrationTestExtensions.cs
@@ -1,6 +1,6 @@
 // <copyright file="IntegrationTestExtensions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/IntegrationTestExtensionsTest.cs
+++ b/src/RiakClientTests.Live/IntegrationTestExtensionsTest.cs
@@ -1,6 +1,6 @@
 // <copyright file="IntegrationTestExtensionsTest.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/LiveRiakConnectionTestBase.cs
+++ b/src/RiakClientTests.Live/LiveRiakConnectionTestBase.cs
@@ -1,6 +1,6 @@
 // <copyright file="LiveRiakConnectionTestBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/LoadTests.cs
+++ b/src/RiakClientTests.Live/LoadTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="LoadTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/MapReduce/RiakMapReduceTestBase.cs
+++ b/src/RiakClientTests.Live/MapReduce/RiakMapReduceTestBase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakMapReduceTestBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/MapReduce/WhenUsingFluentKeyFilters.cs
+++ b/src/RiakClientTests.Live/MapReduce/WhenUsingFluentKeyFilters.cs
@@ -1,6 +1,6 @@
 // <copyright file="WhenUsingFluentKeyFilters.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/MapReduce/WhenUsingSearchAsInput.cs
+++ b/src/RiakClientTests.Live/MapReduce/WhenUsingSearchAsInput.cs
@@ -1,6 +1,6 @@
 // <copyright file="WhenUsingSearchAsInput.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/MapReduceTestHelpers.cs
+++ b/src/RiakClientTests.Live/MapReduceTestHelpers.cs
@@ -1,6 +1,6 @@
 // <copyright file="MapReduceTestHelpers.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/RiakClientTests.cs
+++ b/src/RiakClientTests.Live/RiakClientTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakClientTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/RiakConfigurationTests.cs
+++ b/src/RiakClientTests.Live/RiakConfigurationTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakConfigurationTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/RiakIndexTests.cs
+++ b/src/RiakClientTests.Live/RiakIndexTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/RiakObjectTests.cs
+++ b/src/RiakClientTests.Live/RiakObjectTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakObjectTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/Search/TestSearchAdminOperations.cs
+++ b/src/RiakClientTests.Live/Search/TestSearchAdminOperations.cs
@@ -1,6 +1,6 @@
 // <copyright file="TestSearchAdminOperations.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/Search/TestSearchOperation.cs
+++ b/src/RiakClientTests.Live/Search/TestSearchOperation.cs
@@ -1,6 +1,6 @@
 // <copyright file="TestSearchOperation.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests.Live/SearchTestHelpers.cs
+++ b/src/RiakClientTests.Live/SearchTestHelpers.cs
@@ -1,6 +1,6 @@
 // <copyright file="SearchTestHelpers.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Auth/AuthTestBase.cs
+++ b/src/RiakClientTests/Auth/AuthTestBase.cs
@@ -1,6 +1,6 @@
 // <copyright file="AuthTestBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Auth/CertificateTests.cs
+++ b/src/RiakClientTests/Auth/CertificateTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="CertificateTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Auth/RiakSecurityManagerTests.cs
+++ b/src/RiakClientTests/Auth/RiakSecurityManagerTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSecurityManagerTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Client/ClientTestBase.cs
+++ b/src/RiakClientTests/Client/ClientTestBase.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="ClientTestBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Client/DataTypeTests.cs
+++ b/src/RiakClientTests/Client/DataTypeTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="DataTypeTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Client/MockCluster.cs
+++ b/src/RiakClientTests/Client/MockCluster.cs
@@ -1,6 +1,6 @@
 ﻿// <copyright file="MockCluster.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Client/SetBucketPropertiesTests.cs
+++ b/src/RiakClientTests/Client/SetBucketPropertiesTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="SetBucketPropertiesTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Comms/RoundRobinStrategyTests.cs
+++ b/src/RiakClientTests/Comms/RoundRobinStrategyTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RoundRobinStrategyTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Extensions.cs
+++ b/src/RiakClientTests/Extensions.cs
@@ -1,6 +1,6 @@
 // <copyright file="Extensions.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Json/RiakObjectConversionTests.cs
+++ b/src/RiakClientTests/Json/RiakObjectConversionTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakObjectConversionTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Json/TestObjects.cs
+++ b/src/RiakClientTests/Json/TestObjects.cs
@@ -1,6 +1,6 @@
 // <copyright file="TestObjects.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/KeyFilters/KeyFilterTests.cs
+++ b/src/RiakClientTests/KeyFilters/KeyFilterTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="KeyFilterTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Messages/MessageCodeTests.cs
+++ b/src/RiakClientTests/Messages/MessageCodeTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="MessageCodeTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/BucketKeyInputSerializationTests.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/BucketKeyInputSerializationTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="BucketKeyInputSerializationTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/BucketKeyKeyDataInputSerializationTests.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/BucketKeyKeyDataInputSerializationTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="BucketKeyKeyDataInputSerializationTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/IndexInputSerializationTests.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/IndexInputSerializationTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="IndexInputSerializationTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/MapReduceSerializationTestsBase.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/MapReduceSerializationTestsBase.cs
@@ -1,6 +1,6 @@
 // <copyright file="MapReduceSerializationTestsBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/RiakIndexStaticTests.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/RiakIndexStaticTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakIndexStaticTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/RiakModuleFunctionArgInputSerializationTest.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/RiakModuleFunctionArgInputSerializationTest.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakModuleFunctionArgInputSerializationTest.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/Inputs/SearchInputSerializationTests.cs
+++ b/src/RiakClientTests/Models/MapReduce/Inputs/SearchInputSerializationTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="SearchInputSerializationTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/MapReduce/RiakMapReduceTests.cs
+++ b/src/RiakClientTests/Models/MapReduce/RiakMapReduceTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakMapReduceTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/NValTests.cs
+++ b/src/RiakClientTests/Models/NValTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="NValTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/QuorumTests.cs
+++ b/src/RiakClientTests/Models/QuorumTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="QuorumTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/RiakBucketPropertyTests.cs
+++ b/src/RiakClientTests/Models/RiakBucketPropertyTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakBucketPropertyTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/RiakLinkTests.cs
+++ b/src/RiakClientTests/Models/RiakLinkTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakLinkTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/RiakObjectTests.cs
+++ b/src/RiakClientTests/Models/RiakObjectTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakObjectTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/Search/RiakSearchRequestTests.cs
+++ b/src/RiakClientTests/Models/Search/RiakSearchRequestTests.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RiakSearchRequestTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/Search/RiakSearchResultTests.cs
+++ b/src/RiakClientTests/Models/Search/RiakSearchResultTests.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RiakSearchResultTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/Models/TimeoutTests.cs
+++ b/src/RiakClientTests/Models/TimeoutTests.cs
@@ -1,5 +1,5 @@
 // <copyright file="TimeoutTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2015 - Basho Technologies, Inc.
+// Copyright 2015 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/RiakAsyncClientTests.cs
+++ b/src/RiakClientTests/RiakAsyncClientTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakAsyncClientTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/RiakClientTestBase.cs
+++ b/src/RiakClientTests/RiakClientTestBase.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakClientTestBase.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file

--- a/src/RiakClientTests/RiakSearchTests.cs
+++ b/src/RiakClientTests/RiakSearchTests.cs
@@ -1,6 +1,6 @@
 // <copyright file="RiakSearchTests.cs" company="Basho Technologies, Inc.">
-// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
-// Copyright (c) 2014 - Basho Technologies, Inc.
+// Copyright 2011 - OJ Reeves & Jeremiah Peschka
+// Copyright 2014 - Basho Technologies, Inc.
 //
 // This file is provided to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file


### PR DESCRIPTION
Using (c) or © after the text "Copyright" is redundant. See short Apache license text at the bottom here: http://www.apache.org/licenses/LICENSE-2.0.txt