### PR TITLE
Issue with Disconnect() method [JIRA: CLIENTS-525]

### DIFF
--- a/src/RiakClient/Comms/RiakPbcSocket.cs
+++ b/src/RiakClient/Comms/RiakPbcSocket.cs
@@ -150,6 +150,7 @@ namespace RiakClient.Comms
             {
                 networkStream.Close();
                 networkStream.Dispose();
+                networkStream = null;
             }
         }
 


### PR DESCRIPTION
Currently RiakPbcSocket is using disposed NetworkStream and keep failing
- When node goes offline
- When cluster refuses the socket connection