### PR TITLE
Modified the copy constructor for RiakResult to maintain the state of NodeOffline

### DIFF
--- a/src/RiakClient/RiakResult.cs
+++ b/src/RiakClient/RiakResult.cs
@@ -59,11 +59,17 @@ namespace RiakClient
         }
 
         protected RiakResult(bool isSuccess, ResultCode resultCode, Exception exception, string errorMessage)
+            : this(isSuccess, resultCode, exception, errorMessage, false)
+        {
+        }
+
+        protected RiakResult(bool isSuccess, ResultCode resultCode, Exception exception, string errorMessage, bool nodeOffline)
         {
             this.isSuccess = isSuccess;
             this.resultCode = resultCode;
             this.exception = exception;
             this.errorMessage = errorMessage;
+            this.NodeOffline = nodeOffline;
 
             if (string.IsNullOrWhiteSpace(this.errorMessage) &&
                 exception != null &&

--- a/src/RiakClient/RiakResult{TResult}.cs
+++ b/src/RiakClient/RiakResult{TResult}.cs
@@ -43,7 +43,7 @@ namespace RiakClient
         }
 
         public RiakResult(RiakResult result)
-            : base(result.IsSuccess, result.ResultCode, result.Exception, result.ErrorMessage)
+            : base(result.IsSuccess, result.ResultCode, result.Exception, result.ErrorMessage, result.NodeOffline)
         {
             this.value = default(TResult);
         }


### PR DESCRIPTION
Some commands (like GET) are losing the NodeOffline state when they transfer the RiakResult into RiakResult<TResult>. The result is that if the node goes offline it will not be moved out of the active pool. Commands like EXECUTE work correctly because they return the RiakResult directly. The fix was to modify the constructor of RiakResult<TResult> to maintain the NodeOffline state. Tested by manually killing an active connection and then verifying in code that the node was marked offline.