### PR TITLE
Add tests for various rpberrorresp TTB responses.

### DIFF
--- a/src/RiakClient/Erlang/OtpInputStream.cs
+++ b/src/RiakClient/Erlang/OtpInputStream.cs
@@ -296,6 +296,25 @@ namespace RiakClient.Erlang
         }
 
         /// <summary>
+        /// Can the tag be parsed as a long
+        /// </summary>
+        /// <param name="tag">the tag to check</param>
+        /// <returns>boolean indicating if tag can be parsed as a long.</returns>
+        public bool IsLongTag(byte tag)
+        {
+            switch (tag)
+            {
+                case OtpExternal.SmallIntTag:
+                case OtpExternal.IntTag:
+                case OtpExternal.SmallBigTag:
+                case OtpExternal.LargeBigTag:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
         /// Read an array of bytes
         /// </summary>
         /// <returns>the value as a long.</returns>

--- a/src/RiakClient/Erlang/TtbErrorDecoder.cs
+++ b/src/RiakClient/Erlang/TtbErrorDecoder.cs
@@ -1,0 +1,81 @@
+﻿namespace RiakClient.Erlang
+{
+    using Exceptions;
+    using Util;
+
+    internal static class TtbErrorDecoder
+    {
+        public const string RpbErrorRespAtom = "rpberrorresp";
+        public const string RpbErrorRespEmpty = "No Riak error message or code returned.";
+
+        public static RiakException MaybeRiakError(byte[] response)
+        {
+            RiakException rv = null;
+
+            if (EnumerableUtil.IsNullOrEmpty(response))
+            {
+                string errMsg = "TTB request returned null or zero-length data buffer.";
+                rv = new RiakException(0, errMsg, false);
+            }
+
+            using (var s = new OtpInputStream(response))
+            {
+                string atom;
+                byte tag = s.Peek();
+                switch (tag)
+                {
+                    case OtpExternal.AtomTag:
+                        atom = s.ReadAtom();
+                        if (atom.Equals(RpbErrorRespAtom))
+                        {
+                            throw new RiakException(0, RpbErrorRespEmpty, false);
+                        }
+
+                        break;
+                    case OtpExternal.SmallTupleTag:
+                    case OtpExternal.LargeTupleTag:
+                        int arity = s.ReadTupleHead();
+                        if (arity >= 1)
+                        {
+                            tag = s.Peek();
+                            if (tag == OtpExternal.AtomTag)
+                            {
+                                atom = s.ReadAtom();
+                                if (atom.Equals(RpbErrorRespAtom))
+                                {
+                                    arity--; // We've read one item in the tuple
+                                    string errMsg = RpbErrorRespEmpty;
+                                    int errCode = 0;
+
+                                    for (int i = 0; i < arity; ++i)
+                                    {
+                                        tag = s.Peek();
+                                        if (tag == OtpExternal.BinTag)
+                                        {
+                                            errMsg = s.ReadBinaryAsString();
+                                        }
+                                        else if (s.IsLongTag(tag))
+                                        {
+                                            errCode = (int)s.ReadLong();
+                                        }
+                                        else
+                                        {
+                                            errMsg = string.Format("Unexpected tag {0} in {1}", tag, RpbErrorRespAtom);
+                                            errCode = 0;
+                                            break;
+                                        }
+                                    }
+
+                                    rv = new RiakException(errCode, errMsg, false);
+                                }
+                            }
+                        }
+
+                        break;
+                }
+            }
+
+            return rv;
+        }
+    }
+}

--- a/src/RiakClient/RiakClient.csproj
+++ b/src/RiakClient/RiakClient.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Commands\CommandOptions.cs" />
     <Compile Include="Commands\Response{TValue}.cs" />
     <Compile Include="Commands\TS\DecodedResponse.cs" />
+    <Compile Include="Erlang\TtbErrorDecoder.cs" />
     <Compile Include="Commands\TS\ListKeys.cs" />
     <Compile Include="Commands\TS\ListKeysOptions.cs" />
     <Compile Include="Commands\TS\QueryOptions.cs" />

--- a/src/Test/Test.csproj
+++ b/src/Test/Test.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Unit\TS\CellTests.cs" />
     <Compile Include="Unit\TS\ListKeysTests.cs" />
     <Compile Include="Unit\TS\QueryTests.cs" />
+    <Compile Include="Unit\Erlang\TtbErrorDecoderTests.cs" />
     <Compile Include="Unit\TS\TsCellTests.cs" />
     <Compile Include="Unit\TS\TimeseriesTest.cs" />
     <Compile Include="Unit\TS\StoreTests.cs" />

--- a/src/Test/Unit/Erlang/TtbErrorDecoderTests.cs
+++ b/src/Test/Unit/Erlang/TtbErrorDecoderTests.cs
@@ -1,0 +1,98 @@
+namespace Test.Unit.Erlang
+{
+    using NUnit.Framework;
+    using RiakClient.Erlang;
+    using RiakClient.Exceptions;
+    using RiakClient.Messages;
+
+    [TestFixture, UnitTest]
+    public class TtbErrorDecoderTests
+    {
+        private const string ErrMsg = "error-message";
+        private const int ErrCode = 234;
+
+        [Test]
+        public void Can_Parse_Bare_RpbErrorResp()
+        {
+            byte[] b = null;
+            using (var os = new OtpOutputStream())
+            {
+                os.WriteAtom(TtbErrorDecoder.RpbErrorRespAtom);
+                os.Flush();
+                b = os.ToArray();
+            }
+
+            var ex = Assert.Throws<RiakException>(() => new TsTtbResp(b));
+            Assert.IsTrue(ex.Message.Contains(TtbErrorDecoder.RpbErrorRespEmpty));
+        }
+
+        [Test]
+        public void Can_Parse_RpbErrorResp_In_1_Tuple()
+        {
+            byte[] b = null;
+            using (var os = new OtpOutputStream())
+            {
+                os.WriteTupleHead(1);
+                os.WriteAtom(TtbErrorDecoder.RpbErrorRespAtom);
+                os.Flush();
+                b = os.ToArray();
+            }
+
+            var ex = Assert.Throws<RiakException>(() => new TsTtbResp(b));
+            Assert.IsTrue(ex.Message.Contains(TtbErrorDecoder.RpbErrorRespEmpty));
+        }
+
+        [Test]
+        public void Can_Parse_RpbErrorResp_In_2_Tuple_With_String()
+        {
+            byte[] b = null;
+            using (var os = new OtpOutputStream())
+            {
+                os.WriteTupleHead(2);
+                os.WriteAtom(TtbErrorDecoder.RpbErrorRespAtom);
+                os.WriteStringAsBinary(ErrMsg);
+                os.Flush();
+                b = os.ToArray();
+            }
+
+            var ex = Assert.Throws<RiakException>(() => new TsTtbResp(b));
+            Assert.IsTrue(ex.Message.Contains(ErrMsg));
+        }
+
+        [Test]
+        public void Can_Parse_RpbErrorResp_In_2_Tuple_With_Code()
+        {
+            byte[] b = null;
+            using (var os = new OtpOutputStream())
+            {
+                os.WriteTupleHead(2);
+                os.WriteAtom(TtbErrorDecoder.RpbErrorRespAtom);
+                os.WriteLong(ErrCode);
+                os.Flush();
+                b = os.ToArray();
+            }
+
+            var ex = Assert.Throws<RiakException>(() => new TsTtbResp(b));
+            Assert.IsTrue(ex.Message.Contains(ErrCode.ToString()));
+        }
+
+        [Test]
+        public void Can_Parse_RpbErrorResp_In_3_Tuple()
+        {
+            byte[] b = null;
+            using (var os = new OtpOutputStream())
+            {
+                os.WriteTupleHead(3);
+                os.WriteAtom(TtbErrorDecoder.RpbErrorRespAtom);
+                os.WriteLong(ErrCode);
+                os.WriteStringAsBinary(ErrMsg);
+                os.Flush();
+                b = os.ToArray();
+            }
+
+            var ex = Assert.Throws<RiakException>(() => new TsTtbResp(b));
+            Assert.IsTrue(ex.Message.Contains(ErrCode.ToString()));
+            Assert.IsTrue(ex.Message.Contains(ErrMsg));
+        }
+    }
+}


### PR DESCRIPTION
If Riak returns an `rpberrorresp` that's not a well-formed 3-tuple, we should still handle it.