### PR TITLE
Use timespan ticks, not stopwatch ticks

### DIFF
--- a/src/RiakClientTests/Json/RiakObjectConversionTests.cs
+++ b/src/RiakClientTests/Json/RiakObjectConversionTests.cs
@@ -106,7 +106,7 @@ namespace RiakClientTests.Json.RiakObjectConversionTests
                 obj.SetObject(testPerson);
             }
             sw.Stop();
-            Console.WriteLine("Serialisation took a total of {0} - {1} per iteration", sw.Elapsed, new TimeSpan(sw.ElapsedTicks / iterations));
+            Console.WriteLine("Serialisation took a total of {0} - {1} per iteration", sw.Elapsed, new TimeSpan(sw.Elapsed.Ticks / iterations));
 
             sw.Reset();
             sw.Start();
@@ -117,7 +117,7 @@ namespace RiakClientTests.Json.RiakObjectConversionTests
                 obj.GetObject<Person>();
             }
             sw.Stop();
-            Console.WriteLine("Deserialisation took a total of {0} - {1} per iteration", sw.Elapsed, new TimeSpan(sw.ElapsedTicks / iterations));
+            Console.WriteLine("Deserialisation took a total of {0} - {1} per iteration", sw.Elapsed, new TimeSpan(sw.Elapsed.Ticks / iterations));
         }
 
         [Test]


### PR DESCRIPTION
This is a very minor usage, but a bug nonetheless.  Figured it was easiest just to send you a PR.

In general, don't use the `ElapsedTicks` property of a `System.Diagnostics.Stopwatch` unless you are also going to factor in `Stopwatch.Frequency`.  Since the `Elapsed` property already does this, the easiest fix is `.ElapsedTicks` => `.Elapsed.Ticks`.

(they're not the same thing)